### PR TITLE
Expand README to mirror Modrinth listing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,28 @@
 # AlwaysStats
 
-A simple & lightweight customizable HUD mod to always display the stats you want — no need to hold F3.
+A simple & lightweight customizable HUD mod to always display the stats you want, no need to hold F3.
 
-[Modrinth page](https://modrinth.com/mod/alwaysstats) · [Issues](https://github.com/Andreas-Westh/AlwaysStats/issues)
+[Modrinth page](https://modrinth.com/mod/alwaysstats) can be found here, or check the [issues](https://github.com/Andreas-Westh/AlwaysStats/issues).
 
 ![Ingame Example](https://cdn.modrinth.com/data/GCBmVH41/images/a465a7c4602483afb91f9bfd1ed382bfc3b12102_350.webp)
 
-Made because I just wanted to always see some specific stats. This is my first mod, so feedback is very welcome — it's heavily work in progress and customizability is being expanded.
+Made because I just wanted to always see some specific stats. This is my first mod, so feedback is very welcome! Heavily work in progress, slowly working on customizability.
 
 ## Features
 
 Pick and choose which stats you want on screen. Currently available:
 
-- **FPS** — current frames per second
-- **Biome** — biome name with color-coded temperature (hot/cold)
-- **Coordinates** — player X / Y / Z
-- **Direction** — cardinal direction with optional yaw
-- **Light Level** — block light level at the player's position
-- **Target** — what block or entity you're looking at (with variant detection for many mobs)
-- **Time of Day** — in-game clock with a sleep indicator
+* FPS, current frames per second
+* Biome, with color coded temperature (hot/cold)
+* Coordinates, player X / Y / Z
+* Direction, cardinal direction with optional yaw
+* Light Level, block light at the player's position
+* Target, what block or entity you're looking at (with variant detection for many mobs)
+* Time of Day, in game clock with a sleep indicator
 
 ## Configuration
 
-Open settings via [Mod Menu](https://modrinth.com/mod/modmenu) — powered by [Cloth Config](https://modrinth.com/mod/cloth-config). You can toggle individual stats, change font size (Small / Medium / Large), and pick which screen corner the HUD anchors to.
+Open the settings via [Mod Menu](https://modrinth.com/mod/modmenu), powered by [Cloth Config](https://modrinth.com/mod/cloth-config). You can toggle individual stats, change the font size (Small / Medium / Large), and pick which screen corner the HUD anchors to.
 
 ![Stats settings overview](https://cdn.modrinth.com/data/GCBmVH41/images/90156acee6803dcd06b952dd65b972589d713857_350.webp)
 
@@ -35,14 +35,14 @@ Open settings via [Mod Menu](https://modrinth.com/mod/modmenu) — powered by [C
 | Minecraft | 1.21.11 |
 | Loader | Fabric (>= 0.18.2) |
 | Java | 21 |
-| Side | Client-only |
+| Side | Client only |
 
 Mod Menu and Cloth Config are bundled.
 
 ## Installation
 
 1. Install [Fabric Loader](https://fabricmc.net/use/) for Minecraft 1.21.11.
-2. Download the latest jar from [Modrinth](https://modrinth.com/mod/alwaysstats) (or [GitHub Releases](https://github.com/Andreas-Westh/AlwaysStats/releases)).
+2. Download the latest jar from [Modrinth](https://modrinth.com/mod/alwaysstats), or [GitHub Releases](https://github.com/Andreas-Westh/AlwaysStats/releases).
 3. Drop it into your `mods/` folder.
 4. Launch the game and configure via Mod Menu.
 

--- a/README.md
+++ b/README.md
@@ -1,11 +1,59 @@
 # AlwaysStats
 
-A simple & lightweight HUD mod to always display the stats you want.
+A simple & lightweight customizable HUD mod to always display the stats you want — no need to hold F3.
 
-Modrinth page can be found [here](https://modrinth.com/mod/alwaysstats)
+[Modrinth page](https://modrinth.com/mod/alwaysstats) · [Issues](https://github.com/Andreas-Westh/AlwaysStats/issues)
 
-<img width="252" height="123" alt="Ingame example" src="https://github.com/user-attachments/assets/4a92cbea-d1d7-46e2-8e4d-924fe36c7c01" />
+![Ingame Example](https://cdn.modrinth.com/data/GCBmVH41/images/a465a7c4602483afb91f9bfd1ed382bfc3b12102_350.webp)
 
-Made because I just wanted to always see some specific stats, slowly working on customizability!
+Made because I just wanted to always see some specific stats. This is my first mod, so feedback is very welcome — it's heavily work in progress and customizability is being expanded.
 
-Heavily work in progress.
+## Features
+
+Pick and choose which stats you want on screen. Currently available:
+
+- **FPS** — current frames per second
+- **Biome** — biome name with color-coded temperature (hot/cold)
+- **Coordinates** — player X / Y / Z
+- **Direction** — cardinal direction with optional yaw
+- **Light Level** — block light level at the player's position
+- **Target** — what block or entity you're looking at (with variant detection for many mobs)
+- **Time of Day** — in-game clock with a sleep indicator
+
+## Configuration
+
+Open settings via [Mod Menu](https://modrinth.com/mod/modmenu) — powered by [Cloth Config](https://modrinth.com/mod/cloth-config). You can toggle individual stats, change font size (Small / Medium / Large), and pick which screen corner the HUD anchors to.
+
+![Stats settings overview](https://cdn.modrinth.com/data/GCBmVH41/images/90156acee6803dcd06b952dd65b972589d713857_350.webp)
+
+![Customizable ingame stats example](https://cdn.modrinth.com/data/GCBmVH41/images/e39988bee7bc94539138725159c33080328cb76c_350.webp)
+
+## Requirements
+
+| | |
+|---|---|
+| Minecraft | 1.21.11 |
+| Loader | Fabric (>= 0.18.2) |
+| Java | 21 |
+| Side | Client-only |
+
+Mod Menu and Cloth Config are bundled.
+
+## Installation
+
+1. Install [Fabric Loader](https://fabricmc.net/use/) for Minecraft 1.21.11.
+2. Download the latest jar from [Modrinth](https://modrinth.com/mod/alwaysstats) (or [GitHub Releases](https://github.com/Andreas-Westh/AlwaysStats/releases)).
+3. Drop it into your `mods/` folder.
+4. Launch the game and configure via Mod Menu.
+
+## Building from source
+
+```bash
+./gradlew build
+```
+
+The packaged jar lands in `build/libs/`.
+
+## License
+
+LGPL-3.0-or-later.


### PR DESCRIPTION
## Summary
- Rewrite README around the Modrinth tagline and embed all three gallery images (ingame example, settings overview, customizable stats)
- Add a feature list covering the currently shipped stats and a configuration section pointing at Mod Menu / Cloth Config
- Add a requirements table, install steps, and build command

## Notes
- Modrinth lists the license as CC0-1.0 but `fabric.mod.json` / `LICENSE` say LGPL-3.0-or-later. README follows the repo; worth reconciling the Modrinth listing separately.

## Test plan
- [ ] Render README on the PR page and confirm all three Modrinth CDN images load
- [ ] Verify the Modrinth, Issues, Fabric, Mod Menu, and Cloth Config links resolve

🤖 Generated with [Claude Code](https://claude.com/claude-code)